### PR TITLE
Ensure volume region matches instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ Outputs:
 ec2_ip = 35.177.7.160
 ```
 
+### Changing region and instance types
+
+Different tasks will require different [instance](https://aws.amazon.com/ec2/instance-types/) types. 
+However, some instance types are not available in each region, so it may be necessary to change region.
+Instance type and region can thus be set as arguments along with `terraform apply`:
+
+```
+terraform apply --var username=user --var aws_region=eu-west-1 --var instance_type=c4.2xlarge
+```
+
 ## Install Docker and other tools on the databox
 
 ```

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 variable "aws_region" { default = "eu-west-1" } # London
 variable "username" { default = "databoxuser"}
+variable "instance_type" {default = "t2.micro" }
 
 variable "public_key_path" {
   description = "Enter the path to the SSH Public Key to add to AWS."
@@ -54,7 +55,7 @@ data "aws_ami" "ubuntu" {
 resource "aws_instance" "box" {
     ami           = "${data.aws_ami.ubuntu.id}"
     availability_zone = "${var.aws_region}a"
-    instance_type = "t2.micro"
+    instance_type = "${var.instance_type}"
     security_groups = [
         "${aws_security_group.allow_all_ssh.name}",
         "${aws_security_group.allow_all_outbound.name}"

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,4 @@
-variable "aws_region" { default = "eu-west-2" } # London
+variable "aws_region" { default = "eu-west-1" } # London
 variable "username" { default = "databoxuser"}
 
 variable "public_key_path" {
@@ -53,6 +53,7 @@ data "aws_ami" "ubuntu" {
 
 resource "aws_instance" "box" {
     ami           = "${data.aws_ami.ubuntu.id}"
+    availability_zone = "${var.aws_region}a"
     instance_type = "t2.micro"
     security_groups = [
         "${aws_security_group.allow_all_ssh.name}",

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,4 @@
-variable "aws_region" { default = "eu-west-1" } # London
+variable "aws_region" { default = "eu-west-2" } # London
 variable "username" { default = "databoxuser"}
 variable "instance_type" {default = "t2.micro" }
 


### PR DESCRIPTION
Some instance types are not available in the eu-west-2 region yet, which
is our favoured zone. Fixing the volume region on the volume to match
the instance makes it easy to set the region as a variable in main.tf or
as an argument with `--var` at the command line.