### PR TITLE
Create volume from snapshot_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 # Ansible
 *.retry
 playbooks/databox.retry
+.envrc

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This will use the default settings which are:
 |-u|username|A lookup will be performed using the bash command `whoami`|
 |-v|volume_size|Elastic Block Store volume (hard drive) size|
 |-a|ami_id|ID of a specific image (e.g.: ami-dca37ea5). If left unset, will default to ubuntu. Note that some amis are only available in specific regions, which will need to be specified with `-r`. Note that these images will incur an additional cost.|
+|-s|snapshot_id|The id of a snapshot to be loaded onto the EBS volume. The snapshot must be in the same region as specified in `aws_region`, and it must be the same size or smaller than the size of the volume specified in `volume_size`. Note that a snapshot is not saved before the resources are destroyed with `./databox.sh down`: you will need to make a new snapshot at the AWS console to persist the data.|
 
 *NOTE: Ansible will require you to enter your local sudo password before continuing.*
 
@@ -67,10 +68,8 @@ If you wish to create an instance with some software already configured, you can
 This ami is limited to the eu-west-1 region, so to launch the instance on a p2 (gpu optimised instance - note that it is not campatible with the new p3 instance) use the following command:
 
 ```
-./databox.sh -a ami-dca37ea5 -r eu-west-1 -i p2.xlarge up
+./databox.sh -a ami-1812bb61 -r eu-west-1 -i p2.xlarge up
 ```
-
-Note that the p2/p3 gpu optimised instances are relatively expensive. The above command will launch a databox that costs $0.972/h at current prices, without the cost of data transfer and storage.
 
 #### Connecting to your databox
 

--- a/databox.sh
+++ b/databox.sh
@@ -25,8 +25,12 @@ case $key in
     AMI_ID="$2"
     shift # past argument
     ;;
-    *)
+    -s|--snapshot_id)
+    SNAPSHOT_ID="$2"
+    shift # past argument
+    ;;
             # unknown option
+    *)
     ;;
 esac
 shift # past argument or value
@@ -60,8 +64,13 @@ case "$1" in
         export AMI_ID=""
     fi
 
+    # If I don't specify the AMI id set it to empty string
+    if [ -z "${SNAPSHOT_ID+x}" ]; then
+        export SNAPSHOT_ID=""
+    fi
+
     # Launch Terraform passing that user as parameter
-    terraform apply --var username=$USERNAME --var aws_region=$REGION --var instance_type=$INSTANCE --var volume_size=$VOLUME_SIZE --var ami_id=$AMI_ID
+    terraform apply --var username=$USERNAME --var aws_region=$REGION --var instance_type=$INSTANCE --var volume_size=$VOLUME_SIZE --var ami_id=$AMI_ID --var snapshot_id=$SNAPSHOT_ID
 
     # Get DataBox IP from state after the script completes
     export DATABOX_IP=`terraform output ec2_ip`

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@ variable "aws_region" { default = "eu-west-2" } # London
 variable "username" { default = "databoxuser"}
 variable "instance_type" {default = "t2.micro" }
 variable "volume_size" {default = "40" }
+variable "snapshot_id" {default = "" }
 
 variable "public_key_path" {
   description = "Enter the path to the SSH Public Key to add to AWS."
@@ -93,6 +94,7 @@ resource "aws_instance" "box" {
 resource "aws_ebs_volume" "volume" {
     availability_zone = "${var.aws_region}a"
     size = "${var.volume_size}"
+    snapshot_id = "${var.snapshot_id}"
     tags {
         Name = "DataBoxVolume"
     }

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ variable "instance_type" {default = "t2.micro" }
 variable "volume_size" {default = "40" }
 variable "snapshot_id" {
   default = ""
-  descrption = "Specify a snapshot_id to be used when creating the EBS Volume. Note that this snapshot must be in the same region as the instance, and must be the same size or smaller than the volume as specified in volume_size."
+  description = "Specify a snapshot_id to be used when creating the EBS Volume. Note that this snapshot must be in the same region as the instance, and must be the same size or smaller than the volume as specified in volume_size."
 }
 
 variable "public_key_path" {

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,10 @@ variable "aws_region" { default = "eu-west-2" } # London
 variable "username" { default = "databoxuser"}
 variable "instance_type" {default = "t2.micro" }
 variable "volume_size" {default = "40" }
-variable "snapshot_id" {default = "" }
+variable "snapshot_id" {
+  default = ""
+  descrption = "Specify a snapshot_id to be used when creating the EBS Volume. Note that this snapshot must be in the same region as the instance, and must be the same size or smaller than the volume as specified in volume_size."
+}
 
 variable "public_key_path" {
   description = "Enter the path to the SSH Public Key to add to AWS."


### PR DESCRIPTION
Allow the use of the `-s` flag when calling `./databox.sh up`. This will
pass a snapshot_id, and create the DataBoxVolume from this snapshot.

snapshot_id will need to be discovered from the AWS console.