### PR TITLE
Add argument to allow custom playbooks

### DIFF
--- a/databox.sh
+++ b/databox.sh
@@ -29,6 +29,10 @@ case $key in
     SNAPSHOT_ID="$2"
     shift # past argument
     ;;
+    -p|--playbook)
+    PLAYBOOK="$2"
+    shift # past argument
+    ;;
             # unknown option
     *)
     ;;
@@ -69,6 +73,10 @@ case "$1" in
         export SNAPSHOT_ID=""
     fi
 
+    # If I don't specify the AMI id set it to the default databox.yml
+    if [ -z "${PLAYBOOK+x}" ]; then
+        export PLAYBOOK="playbooks/databox.yml"
+    fi
     # Launch Terraform passing that user as parameter
     terraform apply --var username=$USERNAME --var aws_region=$REGION --var instance_type=$INSTANCE --var volume_size=$VOLUME_SIZE --var ami_id=$AMI_ID --var snapshot_id=$SNAPSHOT_ID
 
@@ -76,7 +84,7 @@ case "$1" in
     export DATABOX_IP=`terraform output ec2_ip`
 
     # Run Ansible script using the above IP address
-    ansible-playbook -i "$DATABOX_IP," -K playbooks/databox.yml -u ubuntu
+    ansible-playbook -i "$DATABOX_IP," -K "$PLAYBOOK" -u ubuntu
     ;;
 "down") echo  "Destroying DataBox"
     # If I don't specify the region use a default value
@@ -100,5 +108,6 @@ case "$1" in
     echo "  -i|--instance - AWS instance type"
     echo "  -v|--volume_size - EBS volume size"
     echo "  -a|--ami_id - AMI id"
+    echo "  -p|--playbook - Ansible playbook for post deployment tasks"
     echo "./databox.sh down - Destroy the DataBox"
 esac

--- a/databox.sh
+++ b/databox.sh
@@ -73,7 +73,7 @@ case "$1" in
         export SNAPSHOT_ID=""
     fi
 
-    # If I don't specify the AMI id set it to the default databox.yml
+    # If I don't specify a custom playback set it to the default: databox.yml
     if [ -z "${PLAYBOOK+x}" ]; then
         export PLAYBOOK="playbooks/databox.yml"
     fi

--- a/main.tf
+++ b/main.tf
@@ -104,7 +104,7 @@ resource "aws_ebs_volume" "volume" {
 }
 
 resource "aws_volume_attachment" "ebs_att" {
-  device_name = "/dev/sdh"
+  device_name = "/dev/xvdh"
   volume_id   = "${aws_ebs_volume.volume.id}"
   instance_id = "${aws_instance.box.id}"
 }

--- a/playbooks/govuk-taxonomy-supervised-learning.yml
+++ b/playbooks/govuk-taxonomy-supervised-learning.yml
@@ -1,0 +1,40 @@
+- name: "Setup Conda AMI for Deep Learning on govuk-taxonomy-supervised-learning"
+  hosts: all
+  become: true
+
+  tasks:
+
+    - name: format the EBS filesystem
+      filesystem:
+        fstype: ext4
+        dev: /dev/xvdh
+
+    - name: configure the EBS volume mount point
+      mount:
+        path: /data
+        src: /dev/xvdh
+        fstype: ext4
+        state: present
+
+    - name: mount the EBS volume
+      mount:
+        path: /data
+        src: /dev/xvdh
+        fstype: ext4
+        state: mounted
+
+    - name: Clone latest govuk-taxonomy-supervised-learning 
+      git:
+        repo: https://github.com/alphagov/govuk-taxonomy-supervised-learning.git
+        dest: /home/ubuntu/govuk-taxonomy-supervised-learning
+
+    - name: Install necessary python packages
+      pip:
+        name: scikit-learn
+        version: 0.19.1
+        virtualenv: /home/ubuntu/anaconda3/envs/tensorflow_p36
+    
+    - name: Set environment variables (sources .env_aws)
+      shell: source .env_aws
+      args:
+        chdir: /home/ubuntu/govuk-taxonomy-supervised-learning

--- a/playbooks/govuk-taxonomy-supervised-learning.yml
+++ b/playbooks/govuk-taxonomy-supervised-learning.yml
@@ -27,6 +27,7 @@
       git:
         repo: https://github.com/alphagov/govuk-taxonomy-supervised-learning.git
         dest: /home/ubuntu/govuk-taxonomy-supervised-learning
+      become_user: ubuntu
 
     - name: Install necessary python packages
       pip:
@@ -38,3 +39,4 @@
       shell: source .env_aws
       args:
         chdir: /home/ubuntu/govuk-taxonomy-supervised-learning
+      become_user: ubuntu


### PR DESCRIPTION
Custom playbooks can be used to set specific instructions for certain projects, e.g. deeplearning. This PR allows playbooks to be passed as arguments (otherwise defaults to `playbooks/databox.yml`) and adds a playbook specific to the govuk-taxonomy-supervised-learning project. In future it may make sense to store these playbooks in their own repo.