### PR TITLE
Output data volume id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -117,3 +117,6 @@ resource "aws_key_pair" "auth" {
 output "ec2_ip" {
     value = "${aws_instance.box.public_ip}"
 }
+output "data_volume_id" {
+    value = "${aws_ebs_volume.volume.id}"
+}


### PR DESCRIPTION
It can be useful to have access to the id of the data volume for
creating snapshots from the command line with:

```
aws ec2 create-snapshot --profile gds-data --volume-id $(terraform
output data_volume_id)
```